### PR TITLE
Add unit tests and coverage plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,25 @@
                     <verbose>true</verbose>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/test/java/com/ansj/vec/Word2VECTest.java
+++ b/src/test/java/com/ansj/vec/Word2VECTest.java
@@ -1,0 +1,56 @@
+package com.ansj.vec;
+
+import com.ansj.vec.domain.WordEntry;
+import java.io.*;
+import java.util.*;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class Word2VECTest {
+    @Test
+    public void testGetFloatAndReadFloat() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        dos.writeFloat(1.5f);
+        dos.flush();
+        byte[] bytes = baos.toByteArray();
+        assertEquals(1.5f, Word2VEC.getFloat(bytes), 0.0001f);
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        assertEquals(1.5f, Word2VEC.readFloat(bais), 0.0001f);
+    }
+
+    @Test
+    public void testLoadModelAndDistance() throws Exception {
+        File temp = File.createTempFile("model", ".bin");
+        temp.deleteOnExit();
+        DataOutputStream dos = new DataOutputStream(new FileOutputStream(temp));
+        dos.writeInt(4); // words
+        dos.writeInt(2); // size
+        writeEntry(dos, "w1", new float[]{1f,0f});
+        writeEntry(dos, "w2", new float[]{0f,1f});
+        writeEntry(dos, "w3", new float[]{1f,1f});
+        writeEntry(dos, "w4", new float[]{0f,2f});
+        dos.close();
+
+        Word2VEC vec = new Word2VEC();
+        vec.setTopNSize(3);
+        vec.loadJavaModel(temp.getAbsolutePath());
+
+        Set<WordEntry> result = vec.distance("w1");
+        for (WordEntry we : result) {
+            assertNotEquals("w1", we.name);
+        }
+        assertTrue(result.size() <= 2);
+
+        List<String> list = Arrays.asList("w1", "w2");
+        Set<WordEntry> result2 = vec.distance(list);
+        assertFalse(result2.isEmpty());
+    }
+
+    private void writeEntry(DataOutputStream dos, String word, float[] vec) throws IOException {
+        dos.writeUTF(word);
+        for (float v : vec) {
+            dos.writeFloat(v);
+        }
+    }
+}

--- a/src/test/java/com/ansj/vec/domain/WordEntryTest.java
+++ b/src/test/java/com/ansj/vec/domain/WordEntryTest.java
@@ -1,0 +1,15 @@
+package com.ansj.vec.domain;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class WordEntryTest {
+    @Test
+    public void testCompareAndString() {
+        WordEntry e1 = new WordEntry("hi", 1f);
+        WordEntry e2 = new WordEntry("bye", 0.5f);
+        assertTrue(e1.compareTo(e2) < 0);
+        assertTrue(e2.compareTo(e1) > 0);
+        assertEquals("hi\t1.0", e1.toString());
+    }
+}

--- a/src/test/java/com/ansj/vec/util/HaffmanTest.java
+++ b/src/test/java/com/ansj/vec/util/HaffmanTest.java
@@ -1,0 +1,22 @@
+package com.ansj.vec.util;
+
+import com.ansj.vec.domain.WordNeuron;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class HaffmanTest {
+    @Test
+    public void testTreeBuildAndCodes() {
+        List<WordNeuron> list = new ArrayList<WordNeuron>();
+        list.add(new WordNeuron("a", 0.5, 3));
+        list.add(new WordNeuron("b", 0.4, 3));
+        list.add(new WordNeuron("c", 0.1, 3));
+        new Haffman(3).make(list);
+        for (WordNeuron wn : list) {
+            assertNotNull(wn.parent);
+            assertTrue(wn.makeNeurons().size() > 0);
+        }
+    }
+}

--- a/src/test/java/com/ansj/vec/util/MapCountTest.java
+++ b/src/test/java/com/ansj/vec/util/MapCountTest.java
@@ -1,0 +1,22 @@
+package com.ansj.vec.util;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class MapCountTest {
+    @Test
+    public void testAddRemoveAndDic() {
+        MapCount<String> mc = new MapCount<String>();
+        mc.add("a");
+        mc.add("a");
+        mc.add("b", 3);
+        assertEquals(2, mc.get().get("a").intValue());
+        assertEquals(3, mc.get().get("b").intValue());
+        String dic = mc.getDic();
+        assertTrue(dic.contains("a\t2"));
+        assertTrue(dic.contains("b\t3"));
+        assertEquals(2, mc.size());
+        mc.remove("a");
+        assertEquals(1, mc.size());
+    }
+}


### PR DESCRIPTION
## Summary
- add jacoco code coverage plugin
- add tests for Word2VEC helpers
- add tests for Haffman tree, WordEntry, MapCount

## Testing
- `mvn -q test` *(fails: Could not resolve jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_683faf3bbb7083269a68140054b4e63f